### PR TITLE
fix DawnWithdraw

### DIFF
--- a/contracts/core/DawnWithdraw.sol
+++ b/contracts/core/DawnWithdraw.sol
@@ -146,20 +146,13 @@ contract DawnWithdraw is IDawnWithdraw, DawnBase, DawnWithdrawStorageLayout {
     // 获取未完成的赎回请求队列(返回的数组index=0的WithdrawRequest是fulfilled)
     function getUnfulfilledWithdrawRequestQueue() public view returns (WithdrawRequest[] memory unfulfilledWithdrawRequestQueue) {
         uint256 lastFulfillmentRequestId = _getUint(_LAST_FULFILLMENT_REQUEST_ID_KEY);
-        uint256 length = withdrawRequestQueue.length - lastFulfillmentRequestId;
+        uint256 lastRequestId = _getUint(_LAST_REQUEST_ID_KEY);
+        uint256 length = lastRequestId - lastFulfillmentRequestId + 1;
         unfulfilledWithdrawRequestQueue = new WithdrawRequest[](length);
 
-        for (uint256 i = lastFulfillmentRequestId; i < withdrawRequestQueue.length; i++) {
+        for (uint256 i = lastFulfillmentRequestId; i <= lastRequestId; i++) {
             unfulfilledWithdrawRequestQueue[i - lastFulfillmentRequestId] = withdrawRequestQueue[i];
         }
-    }
-
-    function getWithdrawRequestQueue() public view returns (WithdrawRequest[] memory) {
-        return withdrawRequestQueue;
-    }
-
-    function getCheckPoints() public view returns (CheckPoint[] memory) {
-        return checkPoints;
     }
 
     function getWithdrawQueueStat() public view returns (uint256 lastFulfillmentRequestId, uint256 lastRequestId, uint256 lastCheckpointIndex) {

--- a/contracts/core/DawnWithdrawStorageLayout.sol
+++ b/contracts/core/DawnWithdrawStorageLayout.sol
@@ -20,6 +20,6 @@ struct CheckPoint {
 
 abstract contract DawnWithdrawStorageLayout {
 
-    WithdrawRequest[] withdrawRequestQueue;
-    CheckPoint[] checkPoints;
+    mapping(uint256 => WithdrawRequest) public withdrawRequestQueue;
+    mapping(uint256 => CheckPoint) public checkPoints;
 }

--- a/contracts/interface/IDawnWithdraw.sol
+++ b/contracts/interface/IDawnWithdraw.sol
@@ -30,8 +30,6 @@ interface IDawnWithdraw {
     function checkFulfillment(uint256 lastRequestIdToBeFulfilled, uint256 ethAmountToLock) external view;
 
     function getUnfulfilledWithdrawRequestQueue() external view returns (WithdrawRequest[] memory unfulfilledWithdrawRequestQueue);
-    function getWithdrawRequestQueue() external view returns (WithdrawRequest[] memory);
-    function getCheckPoints() external view returns (CheckPoint[] memory);
     function getWithdrawQueueStat() external view returns (uint256 lastFulfillmentRequestId, uint256 lastRequestId, uint256 lastCheckpointIndex);
 
     function getUnfulfilledTotalPEth() external view returns (uint256);


### PR DESCRIPTION
1. 调整数据存储结构，将动态数据改为mapping，防止get没数据时revert; 
2. 移除getWithdrawRequestQueue()和getCheckPoints(), 改为直接通过public修饰状态变量，自动生成get函数