### PR TITLE
fix

### DIFF
--- a/contracts/core/DawnDeposit.sol
+++ b/contracts/core/DawnDeposit.sol
@@ -11,9 +11,6 @@ import "../deposit_contract/deposit_contract.sol";
 import "../interface/IBurner.sol";
 import "../interface/IDawnWithdraw.sol";
 
-interface NodeManager {
-    function distributeNodeOperatorRewards(uint256 pethAmount) external;
-}
 
 contract DawnDeposit is IDawnDeposit, DawnTokenPETH, DawnBase {
     using SafeMath for uint256;
@@ -384,8 +381,12 @@ contract DawnDeposit is IDawnDeposit, DawnTokenPETH, DawnBase {
     // distribute pETH as rewards to NodeOperators
     function _distributeNodeOperatorRewards(uint256 rewardsPEth) internal {
         address nodeManagerAddr = _getContractAddress(_NODE_OPERATOR_REGISTER_CONTRACT_NAME);
-        _transfer(address(this), nodeManagerAddr, rewardsPEth);
-        NodeManager(nodeManagerAddr).distributeNodeOperatorRewards(rewardsPEth);
+        IDepositNodeManager nodeManager = IDepositNodeManager(nodeManagerAddr);
+
+        if(nodeManager.getTotalActivatedValidatorsCount() > 0) {
+            _transfer(address(this), nodeManagerAddr, rewardsPEth);
+            nodeManager.distributeNodeOperatorRewards(rewardsPEth);
+        }
     }
 
     function _stake() internal returns (uint256) {

--- a/contracts/core/DawnDeposit.sol
+++ b/contracts/core/DawnDeposit.sol
@@ -241,6 +241,14 @@ contract DawnDeposit is IDawnDeposit, DawnTokenPETH, DawnBase {
             .add(_getUint(_PRE_DEPOSIT_VALIDATORS_KEY).mul(PRE_DEPOSIT_VALUE)) // pre validator balance
             .sub(_getUint(_UNREACHABLE_ETHER_COUNT_KEY)); // unreachable ether
 
+        // negative reward
+        if (beaconBalance.add(availableRewards) <= _getUint(_BEACON_ACTIVE_VALIDATOR_BALANCE_KEY).add(
+            beaconValidators.add(exitedValidators).sub(_getUint(_BEACON_ACTIVE_VALIDATORS_KEY)).mul(DEPOSIT_VALUE_PER_VALIDATOR)
+        )) {
+            totalPEth = totalSupply();
+            return (totalEther, totalPEth);
+        }
+
         uint256 rewards = beaconBalance.add(availableRewards).sub(
             _getUint(_BEACON_ACTIVE_VALIDATOR_BALANCE_KEY).add(
                 beaconValidators.add(exitedValidators).sub(_getUint(_BEACON_ACTIVE_VALIDATORS_KEY)).mul(DEPOSIT_VALUE_PER_VALIDATOR)

--- a/contracts/core/DawnWithdraw.sol
+++ b/contracts/core/DawnWithdraw.sol
@@ -95,7 +95,7 @@ contract DawnWithdraw is IDawnWithdraw, DawnBase, DawnWithdrawStorageLayout {
         // add checkpoint
         checkPoints[lastCheckpointIndex + 1] = CheckPoint(
                     IDawnDeposit(_getContractAddress(_DAWN_DEPOSIT_CONTRACT_NAME)).getTotalPooledEther(),
-                    IERC20(_getContractAddress(_DAWN_DEPOSIT_CONTRACT_NAME)).totalSupply(),
+                    IERC20(_getContractAddress(_DAWN_DEPOSIT_CONTRACT_NAME)).totalSupply() - (endRequest.cumulativePEth - startRequest.cumulativePEth),
                     lastRequestIdToBeFulfilled
         );
 

--- a/contracts/interface/IBurner.sol
+++ b/contracts/interface/IBurner.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.17;
 
 interface IBurner {
     function requestBurnPEth(address from, uint256 amount) external;
+    function requestBurnPEthAndDecreaseEth(address from, uint256 burnedPEthAmount, uint256 decreaseEthAmount) external;
 //    function requestBurnMyPEth(uint256 amount) external;
     function commitPEthToBurn(uint256 burnedPEthAmount) external;
 

--- a/contracts/interface/IDawnDeposit.sol
+++ b/contracts/interface/IDawnDeposit.sol
@@ -10,7 +10,8 @@ interface IDawnDeposit {
     event LogETHRewards(uint256 epochId, uint256 preCLBalance, uint256 postCLBalance, uint256 rewardsVaultBalance);
     event LogTokenRebase(uint256 epochId, uint256 preTotalEther, uint256 preTotalPEth, uint256 postTotalEther, uint256 postTotalPEth);
     event LogPunish(address burnAddress, uint256 pethAmountToBurn);
-    event LogDecreaseEther(address burnAddress, uint256 ethAmountToDecrease);
+    event LogPunishWithEth(address burnAddress, uint256 pethAmountToBurn, uint256 ethAmountToDecrease);
+    event LogDecreaseEther(uint256 ethAmountToDecrease);
 
     // user stake ETH to DawnPool returns pETH
     function stake() external payable returns (uint256);
@@ -46,6 +47,7 @@ interface IDawnDeposit {
 
     function punish(address burnAddress, uint256 pethAmountToBurn) external;
     function punish(address burnAddress, uint256 pethAmountToBurn, uint256 ethAmountToDecrease) external;
+    function increaseUnreachableEtherCount(uint256 count) external;
 
     // calculate the amount of pETH backing an amount of ETH
     function getEtherByPEth(uint256 pEthAmount) external view returns (uint256);


### PR DESCRIPTION
fix:
- 合约DawnDeposit: 方法preCalculateExchangeRate() 计算汇率时，未考虑如果出现奖励为负的情况
- 合约DawnWithdraw: 方法fulfillment(), 计算checkpoint时，为totalPEth未减去当前处理后需要燃烧的PETH量，导致claim时汇率偏小，进而导致的用户不能完全赎回ETH
- 合约DawnDeposit：方法punish(address burnAddress, uint256 pethAmountToBurn, uint256 ethAmountToDecrease)，扣除ethAmountToDecrease Eth时需要和燃烧pethAmountToBurn PEth同时进行
- 合约DawnDeposit: 给运营商发放奖励前，先确保验证者数不能为0